### PR TITLE
Reworked getDefaults and getValidation to use attributes

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -50,8 +50,8 @@ function createModel (sails, name) {
     idAttribute: getPrimaryKey(model),
     urlRoot: path.join(sails.config.blueprints.prefix, name),
     relations: getRelations(sails, model),
-    _defaults: getDefaults(model),
-    _validation: getValidation(model.definition, globalId)
+    _defaults: getDefaults(model._attributes),
+    _validation: getValidation(model._attributes, globalId)
   };
 }
 
@@ -81,9 +81,9 @@ function getRelations (sails, model) {
   });
 }
 
-function getValidation (definition, globalId) {
+function getValidation (attributes, globalId) {
   return _.omit(
-    _.transform(definition, function (validation, attr, key) {
+    _.transform(attributes, function (validation, attr, key) {
       validation[key] = _.pick(attr, rules);
       if (_.isEmpty(attr.model) && _.isEmpty(attr.collection)) {
         validation[key][attr.type] = true;
@@ -94,11 +94,14 @@ function getValidation (definition, globalId) {
   );
 }
 
-function getDefaults (model) {
-  return _.object(
-    _.filter(_.keys(model.definition), _.partial(_.has, 'defaultsTo')),
-    _.pluck(_.values(model.definition), 'defaultsTo')
-  );
+function getDefaults (attributes) {
+  var defaults = {};
+  _.each(attributes, function(value, key){
+    if (_.has(value, "defaultsTo")){
+      defaults[key] = value.defaultsTo;
+    }
+  });
+  return defaults;
 }
 
 /**


### PR DESCRIPTION
The "required" attribute isn't available in model.definitions, but it is present in model._attributes.  Switching to this data results in this information getting stored in the BackboneModels.

Also, defaults were not returning as it seems the code was written for data in a different structure than either definitions or _attributes has it stored.  Here is an example of how I found each of the getDefaults methods to work: http://jsfiddle.net/hsj73onw/  I switched to _attributes for consistency sake though it didn't seem to be required as the "defaultsTo" property appears in both places.
